### PR TITLE
optionally skipping send via whitelist closure

### DIFF
--- a/KinMigrationModule.podspec
+++ b/KinMigrationModule.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = 'KinMigrationModule'
-  s.version      = '0.0.9'
+  s.version      = '0.0.10'
   s.summary      = 'Pod for the Kin migration.'
   s.description  = 'Pod for the KinCore to KinSDK migration.'
   s.homepage     = 'https://github.com/kinecosystem/kin-migration-module-ios'

--- a/KinMigrationModule/KinMigrationModule/KinTypes.swift
+++ b/KinMigrationModule/KinMigrationModule/KinTypes.swift
@@ -78,7 +78,7 @@ public protocol KinAccountProtocol {
     func watchPayments(cursor: String?) throws -> PaymentWatchProtocol
 }
 
-public typealias WhitelistClosure = (TransactionEnvelope)->(Promise<(TransactionEnvelope, Bool)>)
+public typealias WhitelistClosure = (TransactionEnvelope) -> Promise<TransactionEnvelope?>
 
 public enum AccountStatus: Int {
     case notCreated

--- a/KinMigrationModule/KinMigrationModule/KinTypes.swift
+++ b/KinMigrationModule/KinMigrationModule/KinTypes.swift
@@ -78,7 +78,7 @@ public protocol KinAccountProtocol {
     func watchPayments(cursor: String?) throws -> PaymentWatchProtocol
 }
 
-public typealias WhitelistClosure = (TransactionEnvelope)->(Promise<TransactionEnvelope>)
+public typealias WhitelistClosure = (TransactionEnvelope)->(Promise<(TransactionEnvelope, Bool)>)
 
 public enum AccountStatus: Int {
     case notCreated

--- a/KinMigrationModule/KinMigrationModule/WrappedKinSDK/WrappedKinSDKAccount.swift
+++ b/KinMigrationModule/KinMigrationModule/WrappedKinSDK/WrappedKinSDKAccount.swift
@@ -70,11 +70,14 @@ class WrappedKinSDKAccount: KinAccountProtocol {
         let promise = Promise<TransactionId>()
 
         account.generateTransaction(to: recipient, kin: kin, memo: memo, fee: fee)
-            .then { transactionEnvelope -> Promise<(TransactionEnvelope, Bool)> in
+            .then { transactionEnvelope -> Promise<TransactionEnvelope?> in
                 return whitelist(transactionEnvelope)
             }
-            .then { [weak self] transactionEnvelope, send -> Promise<TransactionId> in
-                guard send else { return promise.signal("") }
+            .then { [weak self] transactionEnvelope -> Promise<TransactionId> in
+                guard let transactionEnvelope = transactionEnvelope else {
+                    return promise.signal("")
+                }
+
                 guard let strongSelf = self else {
                     return promise.signal(KinError.internalInconsistency)
                 }

--- a/KinMigrationModule/KinMigrationModule/WrappedKinSDK/WrappedKinSDKAccount.swift
+++ b/KinMigrationModule/KinMigrationModule/WrappedKinSDK/WrappedKinSDKAccount.swift
@@ -70,10 +70,11 @@ class WrappedKinSDKAccount: KinAccountProtocol {
         let promise = Promise<TransactionId>()
 
         account.generateTransaction(to: recipient, kin: kin, memo: memo, fee: fee)
-            .then { transactionEnvelope -> Promise<TransactionEnvelope> in
+            .then { transactionEnvelope -> Promise<(TransactionEnvelope, Bool)> in
                 return whitelist(transactionEnvelope)
             }
-            .then { [weak self] transactionEnvelope -> Promise<TransactionId> in
+            .then { [weak self] transactionEnvelope, send -> Promise<TransactionId> in
+                guard send else { return promise.signal("") }
                 guard let strongSelf = self else {
                     return promise.signal(KinError.internalInconsistency)
                 }

--- a/KinMigrationSampleApp/KinMigrationSampleApp/Controllers/MigrationController.swift
+++ b/KinMigrationSampleApp/KinMigrationSampleApp/Controllers/MigrationController.swift
@@ -115,8 +115,8 @@ extension MigrationController: KinMigrationManagerDelegate {
 
 extension MigrationController {
     static func whitelist(url: URL, networkId: String) -> WhitelistClosure {
-        return { transactionEnvelope -> Promise<TransactionEnvelope> in
-            let promise: Promise<TransactionEnvelope> = Promise()
+        return { transactionEnvelope -> Promise<TransactionEnvelope?> in
+            let promise: Promise<TransactionEnvelope?> = Promise()
             let whitelistEnvelope = WhitelistEnvelope(transactionEnvelope: transactionEnvelope, networkId: networkId)
 
             var request = URLRequest(url: url)


### PR DESCRIPTION
For migration module implementors that don't want to transmit the transaction to the blockchain, but still want the transaction envelope generated by the `sendTransaction` method, that on a migration module environment is actually implemented by `WrappedKinSDKAccount`, this allows skipping sending to blockchain and still handling the envelope in the whitelist closure with minimal inteface changes outside of the migration module.
